### PR TITLE
Feat: color placeholders

### DIFF
--- a/docs/docs/ThemeSpecification/colors.mdx
+++ b/docs/docs/ThemeSpecification/colors.mdx
@@ -152,6 +152,26 @@ an example of usage, and the correspondent output:
 | borderRightColor  | borderRightColor  | `{ borderRightColor: "secondary.light"} `  | `{"borderRightColor":"#e563b3"}`  |
 | borderBottomColor | borderBottomColor | `{ borderBottomColor: "secondary.light"} ` | `{"borderBottomColor":"#e563b3"}` |
 
+## Color Placeholders
+
+Color placeholders allow to share a color between multiple keys with no need to duplicate it.
+
+### Example 
+```typescript
+const colors: Colors = {
+  // main palette
+  dark: '#000000',
+  light: '#ffffff',
+  primary: '#06f',
+  secondary: '#db2494'
+  // functional palette
+  background: '$light', // it will be resolved as #ffffff
+  foreground: '$dark', // it will be resolved as #000000
+  borderColor: '$primary', // it will be resolved as #06f
+  ctaColor: '$secondary' // it will be resolved as #db2494
+}
+```
+
 ## Extend Slice with custom properties
 
 If you're using typescript and you add custom colors to your theme configuration, you'll need to merge

--- a/docs/docs/ThemeSpecification/colors.mdx
+++ b/docs/docs/ThemeSpecification/colors.mdx
@@ -154,7 +154,7 @@ an example of usage, and the correspondent output:
 
 ## Color Placeholders
 
-Color placeholders allow to share a color between multiple keys with no need to duplicate it.
+Color placeholders allow referring to another theme color by prefixing it with the character `$`:
 
 ### Example 
 ```typescript

--- a/packages/core/src/parsers/colors/colors.ts
+++ b/packages/core/src/parsers/colors/colors.ts
@@ -3,10 +3,12 @@ import {
   colorSchemasProperties,
   ColorProperty,
   Style,
+  Color
 } from '@morfeo/spec';
 import { ParserParams, SliceParsers } from '../../types';
 import { baseParser } from '../baseParser';
 import { theme } from '../../theme';
+import { placeholderParser } from './placeholderParsers';
 
 type ColorsParsers = SliceParsers<
   typeof colorProperties,
@@ -36,6 +38,14 @@ export function parseColor({
         scale: 'colors',
       });
     }
+  }
+
+  console.log(value)
+
+  const color = theme.getValue('colors', value as Color);
+
+  if (color && color.indexOf('$') === 0) {
+    return placeholderParser({ value, property, color, });
   }
 
   return baseParser({

--- a/packages/core/src/parsers/colors/colors.ts
+++ b/packages/core/src/parsers/colors/colors.ts
@@ -40,7 +40,6 @@ export function parseColor({
     }
   }
 
-  console.log(value);
 
   const color = theme.getValue('colors', value as Color);
 

--- a/packages/core/src/parsers/colors/colors.ts
+++ b/packages/core/src/parsers/colors/colors.ts
@@ -3,7 +3,7 @@ import {
   colorSchemasProperties,
   ColorProperty,
   Style,
-  Color
+  Color,
 } from '@morfeo/spec';
 import { ParserParams, SliceParsers } from '../../types';
 import { baseParser } from '../baseParser';
@@ -40,12 +40,12 @@ export function parseColor({
     }
   }
 
-  console.log(value)
+  console.log(value);
 
   const color = theme.getValue('colors', value as Color);
 
   if (color && color.indexOf('$') === 0) {
-    return placeholderParser({ value, property, color, });
+    return placeholderParser({ value, property, color });
   }
 
   return baseParser({

--- a/packages/core/src/parsers/colors/placeholderParsers.ts
+++ b/packages/core/src/parsers/colors/placeholderParsers.ts
@@ -22,7 +22,7 @@ export const placeholderParser = ({
 
   return baseParser({
     value: originalValue as Color,
-    property: property === 'bg' ? 'backgroundColor' : property,
+    property,
     scale: 'colors',
   });
 };

--- a/packages/core/src/parsers/colors/placeholderParsers.ts
+++ b/packages/core/src/parsers/colors/placeholderParsers.ts
@@ -8,21 +8,21 @@ export const placeholderParser = ({
   property,
   color,
 }: ParserParams<ColorProperty> & { color: string }) => {
-    const originalValue = color.substring(1);
-    const originalAssignedStyle = theme.getValue(
-      'colors',
-      originalValue as Color,
-    );
+  const originalValue = color.substring(1);
+  const originalAssignedStyle = theme.getValue(
+    'colors',
+    originalValue as Color,
+  );
 
-    if (!originalAssignedStyle) {
-      return {
-        [property]: value,
-      };
-    }
+  if (!originalAssignedStyle) {
+    return {
+      [property]: value,
+    };
+  }
 
-    return baseParser({
-      value: originalValue as Color,
-      property: property === 'bg' ? 'backgroundColor' : property,
-      scale: 'colors',
-    });
+  return baseParser({
+    value: originalValue as Color,
+    property: property === 'bg' ? 'backgroundColor' : property,
+    scale: 'colors',
+  });
 };

--- a/packages/core/src/parsers/colors/placeholderParsers.ts
+++ b/packages/core/src/parsers/colors/placeholderParsers.ts
@@ -1,0 +1,28 @@
+import { ParserParams } from '../../types';
+import { Color, ColorProperty } from '@morfeo/spec';
+import { theme } from '../../theme';
+import { baseParser } from '../baseParser';
+
+export const placeholderParser = ({
+  value,
+  property,
+  color,
+}: ParserParams<ColorProperty> & { color: string }) => {
+    const originalValue = color.substring(1);
+    const originalAssignedStyle = theme.getValue(
+      'colors',
+      originalValue as Color,
+    );
+
+    if (!originalAssignedStyle) {
+      return {
+        [property]: value,
+      };
+    }
+
+    return baseParser({
+      value: originalValue as Color,
+      property: property === 'bg' ? 'backgroundColor' : property,
+      scale: 'colors',
+    });
+};

--- a/packages/core/tests/parsers/colors.test.ts
+++ b/packages/core/tests/parsers/colors.test.ts
@@ -5,8 +5,9 @@ const THEME = {
   colors: {
     primary: '#e3e3e3',
     secondary: '#000',
-    background: '#e3e3e3',
-    foreground: '#000',
+    accent: '$light',
+    background: '$primary',
+    foreground: '$secondary',
   },
   colorSchemas: {
     default: {
@@ -57,5 +58,16 @@ describe('colors', () => {
       colorSchema: 'default',
     });
     expect(result).toEqual({ backgroundColor: 'unexistingValue' });
+  });
+
+  test('should resolve color placeholders', () => {
+    // @ts-expect-error
+    const result = parsers.resolve({ bg: 'background', color: 'foreground' });
+    expect(result).toEqual({ backgroundColor: '#e3e3e3', color: '#000' });
+  });
+
+  test('should return input values if the placeholder is wrong', () => {
+    const result = parsers.resolve({ bg: 'accent' });
+    expect(result).toEqual({ backgroundColor: 'accent' });
   });
 });


### PR DESCRIPTION
# Proposed changes

## Color Placeholders

Color placeholders allow to share a color between multiple keys with no need to duplicate it.

### Example 
```typescript
const colors: Colors = {
  // main palette
  dark: '#000000',
  light: '#ffffff',
  primary: '#06f',
  secondary: '#db2494',
  // functional palette
  background: '$light', // it will be resolved as #ffffff
  foreground: '$dark', // it will be resolved as #000000
  borderColor: '$primary', // it will be resolved as #06f
  ctaColor: '$secondary' // it will be resolved as #db2494
}
```

## Types of changes

- [ ] 🐛 Bugfix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality or enhancements)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ✅ Tests (added tests for an existing feature)
- [x] 📚 Documentation Update (if none of the other choices apply)
- [ ] 🙌 Other (please, write a clear and concise description of the proposal in the section above)

## Checklist

- [x] 👀 I have read the [CONTRIBUTING](https://github.com/morfeojs/morfeo/blob/main/CONTRIBUTING.md) doc
- [x] ✅ Lint and unit tests pass locally with my changes
- [x] 🧪 I have added tests that prove my fix is effective or that my feature works
- [x] 📚 I have added the necessary documentation (if appropriate)
- [x] 🔀 Any dependent changes have been merged and published in downstream modules
