### PR TITLE
feat: #648 - added support for symbols

### DIFF
--- a/packages/jss/src/generateClassName.ts
+++ b/packages/jss/src/generateClassName.ts
@@ -1,12 +1,35 @@
 function getClassNameGenerator() {
   const cache = new Map<string, string>();
 
+  const symbolsMap = {
+    '*': 'all',
+    '.': 'dot',
+    ',': 'comma',
+    '>': 'grtr',
+    '+': 'plus',
+    '~': 'tld',
+    '[': 'sqropn',
+    ']': 'sqrclsd',
+    '^': 'crt',
+    $: 'dlr',
+    '|': 'or',
+    '(': 'opn',
+    ')': 'clsd',
+    '=': 'eql',
+  };
+
   function escapeString(string: string) {
     if (cache.has(string)) {
       return cache.get(string);
     }
 
-    const escaped = string.replace(/[^\w\s-]/gi, '').trim();
+    const replaced = Object.keys(symbolsMap).reduce(
+      (acc, symbol) =>
+        acc.replace(new RegExp('\\' + symbol, 'gi'), symbolsMap[symbol]),
+      string,
+    );
+
+    const escaped = replaced.replace(/[^\w-]/gi, '');
     cache.set(string, escaped);
 
     return escaped;

--- a/packages/jss/tests/generateClassName.test.ts
+++ b/packages/jss/tests/generateClassName.test.ts
@@ -24,4 +24,14 @@ describe('generateClassName', () => {
 
     expect(className).toBe('p-bg-primary');
   });
+
+  it('should convert symbols into plain text', () => {
+    const className = generateClassName({
+      '& div > p': {
+        bg: 'primary',
+      },
+    });
+
+    expect(className).toBe('divgrtrp-bg-primary');
+  });
 });

--- a/packages/spec/src/properties/colors.ts
+++ b/packages/spec/src/properties/colors.ts
@@ -4,6 +4,7 @@ export const colorsMap = [
   'color',
   'stroke',
   'caretColor',
+  'accentColor',
   'borderColor',
   'outlineColor',
   'borderTopColor',


### PR DESCRIPTION
# Proposed changes

Added support for complex styles:

```typescript
const useClasses = createUseClasses({
   p: 'm',
   '& > p, input[type=text]': {
      color: 'text'
   },
});
```

## Types of changes

- [ ] 🐛 Bugfix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality or enhancements)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✅ Tests (added tests for an existing feature)
- [ ] 📚 Documentation Update (if none of the other choices apply)
- [ ] 🙌 Other (please, write a clear and concise description of the proposal in the section above)

## Checklist

- [x] 👀 I have read the [CONTRIBUTING](https://github.com/morfeojs/morfeo/blob/main/CONTRIBUTING.md) doc
- [x] ✅ Lint and unit tests pass locally with my changes
- [ ] 🧪 I have added tests that prove my fix is effective or that my feature works
- [ ] 📚 I have added the necessary documentation (if appropriate)
- [x] 🔀 Any dependent changes have been merged and published in downstream modules
