### PR TITLE
fix(babel-plugin): fixed handling of default styles

### DIFF
--- a/packages/babel-plugin/src/utils/splitStyles.ts
+++ b/packages/babel-plugin/src/utils/splitStyles.ts
@@ -5,13 +5,28 @@ function isStyle(value: unknown): value is Style {
   return typeof value === 'object';
 }
 
+function isDefaultObject(
+  value: Record<string, unknown>,
+): value is { default: unknown } {
+  return !!value.default;
+}
+
 export function splitStyles(object: Style): Style[] {
   const pairs = Object.entries(object);
 
   return pairs.reduce<Style[]>((acc, [key, value]) => {
     if (isStyle(value)) {
       const result = splitStyles(value);
-      return [...acc, ...result.map(curr => ({ [key]: curr }))];
+      return [
+        ...acc,
+        ...result.map(curr => {
+          if (isDefaultObject(curr)) {
+            return { [key]: curr.default } as Style;
+          }
+
+          return { [key]: curr };
+        }),
+      ];
     }
 
     // Dynamic themeable values are skipped since they're resolved in another process

--- a/packages/babel-plugin/tests/splitStyles.test.ts
+++ b/packages/babel-plugin/tests/splitStyles.test.ts
@@ -37,5 +37,16 @@ describe('splitStyles', () => {
         { '&:hover': { bg: 'primary' } },
       ]);
     });
+
+    it('should handle responsive properties with default values', () => {
+      const result = splitStyles({
+        p: {
+          default: 'l',
+          lg: 'm',
+        },
+      });
+
+      expect(result).toEqual([{ p: 'l' }, { p: { lg: 'm' } }]);
+    });
   });
 });

--- a/packages/core/src/theme/createTheme.ts
+++ b/packages/core/src/theme/createTheme.ts
@@ -27,7 +27,10 @@ export function createTheme() {
     const breakpoints = getSlice('breakpoints');
     if (typeof value === 'object' && breakpoints) {
       const keys = Object.keys(value);
-      return keys.some(key => breakpoints[key] !== undefined);
+      return (
+        keys.includes('default') ||
+        keys.some(key => breakpoints[key] !== undefined)
+      );
     }
 
     return false;


### PR DESCRIPTION
# Proposed changes

fixed handling of default styles for responsive objects at build time

## Types of changes

- [x] 🐛 Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] 👀 I have read the [CONTRIBUTING](https://github.com/morfeojs/morfeo/blob/main/CONTRIBUTING.md) doc
- [x] ✅ Lint and unit tests pass locally with my changes
- [x] 🧪 I have added tests that prove my fix is effective or that my feature works
- [x] 📚 I have added the necessary documentation (if appropriate)
- [x] 🔀 Any dependent changes have been merged and published in downstream modules
